### PR TITLE
[pom] Set argline just as a property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,20 +146,9 @@
             <activation>
                 <jdk>[17,)</jdk>
             </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <configuration>
-                                <fork>true</fork>
-                                <argLine>${argLine} -Djdk.attach.allowAttachSelf --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</argLine>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
+            <properties>
+                <argLine>-Djdk.attach.allowAttachSelf --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</argLine>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
also dropped 'fork' as not part of surefire that way any more and was not needed.