### PR TITLE
Move volatile to static class holder, remove double lock, update test to 100%

### DIFF
--- a/src/main/java/org/mybatis/caches/ignite/IgniteCacheAdapter.java
+++ b/src/main/java/org/mybatis/caches/ignite/IgniteCacheAdapter.java
@@ -60,9 +60,6 @@ public final class IgniteCacheAdapter implements Cache {
    */
   private final ReadWriteLock readWriteLock = new DummyReadWriteLock();
 
-  /** Ignite thin client (shared across all adapter instances). Lazily initialized. */
-  private static volatile IgniteClient sharedClient;
-
   /** This adapter's Ignite client. */
   private final IgniteClient client;
 
@@ -81,18 +78,16 @@ public final class IgniteCacheAdapter implements Cache {
   /** Table value column name. */
   static final String VAL_COL = "val";
 
+  /** Ignite thin client (shared across all adapter instances). Lazily initialized. */
+  private static class ClientHolder {
+    private static final IgniteClient INSTANCE = createIgniteClient();
+  }
+
   /**
    * Returns the shared {@link IgniteClient}, creating it lazily on first call.
    */
   private static IgniteClient getOrCreateIgniteClient() {
-    if (sharedClient == null) {
-      synchronized (IgniteCacheAdapter.class) {
-        if (sharedClient == null) {
-          sharedClient = createIgniteClient();
-        }
-      }
-    }
-    return sharedClient;
+    return ClientHolder.INSTANCE;
   }
 
   /**

--- a/src/test/java/org/mybatis/caches/ignite/IgniteCacheAdapterUnitTest.java
+++ b/src/test/java/org/mybatis/caches/ignite/IgniteCacheAdapterUnitTest.java
@@ -41,11 +41,15 @@ import org.apache.ignite.table.IgniteTables;
 import org.apache.ignite.table.KeyValueView;
 import org.apache.ignite.table.Table;
 import org.apache.ignite.table.Tuple;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
@@ -71,7 +75,6 @@ class IgniteCacheAdapterUnitTest {
   @Mock
   private Table mockTable;
 
-  @SuppressWarnings("unchecked")
   @Mock
   private KeyValueView<Tuple, Tuple> mockKvView;
 
@@ -236,23 +239,6 @@ class IgniteCacheAdapterUnitTest {
   }
 
   @Test
-  void shouldUseExistingSharedClientWhenAlreadyInitialized() throws Exception {
-    // Inject the already-configured mockClient as the static sharedClient so the public constructor
-    // takes the non-null fast path through getOrCreateIgniteClient() without connecting to Ignite.
-    java.lang.reflect.Field field = IgniteCacheAdapter.class.getDeclaredField("sharedClient");
-    field.setAccessible(true);
-    IgniteClient previous = (IgniteClient) field.get(null);
-    field.set(null, mockClient);
-    try {
-      IgniteCacheAdapter adapter = new IgniteCacheAdapter(DEFAULT_ID);
-      assertNotNull(adapter);
-      assertEquals(DEFAULT_ID, adapter.getId());
-    } finally {
-      field.set(null, previous);
-    }
-  }
-
-  @Test
   void shouldFallbackToDefaultAddressWhenConfigFileMissing() throws Exception {
     // Hide the config file so createIgniteClient() takes the IOException fallback branch,
     // then verify it throws because no Ignite server is reachable.
@@ -268,4 +254,44 @@ class IgniteCacheAdapterUnitTest {
       Files.move(cfgBkp, cfgFile, StandardCopyOption.REPLACE_EXISTING);
     }
   }
+
+  @Test
+  void shouldCreateIgniteClientFromConfigFile() throws Exception {
+    try (MockedStatic<IgniteClient> igniteClient = Mockito.mockStatic(IgniteClient.class)) {
+      IgniteClient.Builder builder = mock(IgniteClient.Builder.class);
+      IgniteClient client = mock(IgniteClient.class);
+
+      igniteClient.when(IgniteClient::builder).thenReturn(builder);
+      when(builder.addresses(any(String[].class))).thenReturn(builder);
+      when(builder.build()).thenReturn(client);
+
+      IgniteClient result = IgniteCacheAdapter.createIgniteClient();
+
+      Assertions.assertSame(client, result);
+      verify(builder).addresses("127.0.0.1:10800");
+    }
+  }
+
+  @Test
+  void shouldCreateAdapterUsingDefaultConstructor() {
+    Path cfgFile = Path.of(IgniteCacheAdapter.CFG_PATH);
+    Assumptions.assumeTrue(Files.exists(cfgFile), "Config file not present");
+
+    try (MockedStatic<IgniteClient> igniteClient = Mockito.mockStatic(IgniteClient.class)) {
+      IgniteClient.Builder builder = mock(IgniteClient.Builder.class);
+      IgniteClient client = mock(IgniteClient.class, Answers.RETURNS_DEEP_STUBS);
+
+      igniteClient.when(IgniteClient::builder).thenReturn(builder);
+      when(builder.addresses(any(String[].class))).thenReturn(builder);
+      when(builder.build()).thenReturn(client);
+
+      IgniteCacheAdapter adapter = new IgniteCacheAdapter(DEFAULT_ID);
+
+      assertEquals(DEFAULT_ID, adapter.getId());
+
+      verify(builder).addresses("127.0.0.1:10800");
+      verify(builder).build();
+    }
+  }
+
 }


### PR DESCRIPTION
Also known as the Initialization-on-Demand Holder Idiom, this approach leverages the Java Language Specification's guarantees about how and when inner classes are loaded.

Why it’s better:

- Thread-Safe by Design: The JVM guarantees that a class is initialized only when it is actively used. The Holder class is not loaded into memory until getInstance() is called for the first time. Because class initialization is thread-safe by JVM specification, you need zero synchronization blocks, locks, or volatile keywords.

- Read Performance: Subsequent calls to getInstance() bypass all synchronization overhead, meaning it executes at full native speed.

- Readability: It avoids the complex boilerplate of checking nulls twice (if (instance == null)).